### PR TITLE
add inline scripting feature for accessing out yaml tree

### DIFF
--- a/src/.astylerc
+++ b/src/.astylerc
@@ -15,7 +15,7 @@
 --indent-switches
 --indent-col1-comments
 --min-conditional-indent=2
---max-instatement-indent=100
---add-brackets
+--max-continuation-indent=100
+--add-braces
 --lineend=linux
 --convert-tabs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ project(chatterbox_binary VERSION 0.0.0)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options(-Wall -std=c++17)
+# add_compile_options(-g -Wall -std=c++17)
 endif()
 
 add_definitions(-DV8_COMPRESS_POINTERS

--- a/src/conversation.h
+++ b/src/conversation.h
@@ -48,6 +48,12 @@ struct conversation {
     //parent
     scenario &parent_;
 
+    //scenario property resolver
+    scenario_property_resolver &scen_out_p_resolv_;
+
+    //scenario property evaluator
+    scenario_property_evaluator &scen_p_evaluator_;
+
     //js environment
     js::js_env &js_env_;
 

--- a/src/jsenv.cpp
+++ b/src/jsenv.cpp
@@ -70,7 +70,6 @@ int js_env::reset()
                                       v8::NewStringType::kNormal).ToLocalChecked(),
               v8::FunctionTemplate::New(isolate_, cbk_log));
 
-
   //bind cbk_load.
   global->Set(v8::String::NewFromUtf8(isolate_,
                                       "load",

--- a/src/jsenv.h
+++ b/src/jsenv.h
@@ -18,8 +18,7 @@ struct converter<bool> {
     if(!val.is_keyval() && !val.is_val()) {
       return false;
     }
-    bool bval;
-    val >> bval;
+    //@todo
     return true;
   }
   static bool isType(const v8::Local<v8::Value> &val) {
@@ -44,8 +43,7 @@ struct converter<int32_t> {
     if(!val.is_keyval() && !val.is_val()) {
       return false;
     }
-    int32_t ival;
-    val >> ival;
+    //@todo
     return true;
   }
   static bool isType(const v8::Local<v8::Value> &val) {
@@ -70,8 +68,7 @@ struct converter<uint32_t> {
     if(!val.is_keyval() && !val.is_val()) {
       return false;
     }
-    uint32_t uival;
-    val >> uival;
+    //@todo
     return true;
   }
   static bool isType(const v8::Local<v8::Value> &val) {
@@ -96,8 +93,7 @@ struct converter<double> {
     if(!val.is_keyval() && !val.is_val()) {
       return false;
     }
-    double dval;
-    val >> dval;
+    //@todo
     return true;
   }
   static bool isType(const v8::Local<v8::Value> &val) {
@@ -122,8 +118,7 @@ struct converter<std::string> {
     if(!val.is_keyval() && !val.is_val()) {
       return false;
     }
-    std::string sval;
-    val >> sval;
+    //@todo
     return true;
   }
   static bool isType(const v8::Local<v8::Value> &val) {
@@ -219,7 +214,7 @@ struct js_env {
   static void cbk_assert(const v8::FunctionCallbackInfo<v8::Value> &args);
 
   // ----------------------------
-  // --- Json Field Evaluator ---
+  // --- Yaml Field Evaluator ---
   // ----------------------------
 
   template <typename T>
@@ -227,11 +222,22 @@ struct js_env {
                            const char *key,
                            const std::optional<T> default_value = std::nullopt,
                            bool log_errors = true,
-                           bool *is_error = nullptr) {
+                           bool *is_error = nullptr,
+                           const char *check_regex = nullptr,
+                           bool *further_eval = nullptr) {
     if(!from.has_child(ryml::to_csubstr(key))) {
       return default_value;
     }
     ryml::NodeRef val = from[ryml::to_csubstr(key)];
+
+    if(check_regex && (val.is_keyval() || val.is_val())) {
+      auto str_val = utils::converter<std::string>::asType(val);
+      if(std::regex_search(utils::converter<std::string>::asType(val), std::regex(check_regex))) {
+        *further_eval = true;
+        return std::nullopt;
+      }
+    }
+
     if(utils::converter<T>::isType(val)) {
       //eval as primitive value
       return utils::converter<T>::asType(val);

--- a/src/request.h
+++ b/src/request.h
@@ -108,6 +108,12 @@ struct request {
     //ryml request out support buffer
     std::vector<char> ryml_request_out_buf_;
 
+    //scenario property resolver
+    scenario_property_resolver &scen_out_p_resolv_;
+
+    //scenario property evaluator
+    scenario_property_evaluator &scen_p_evaluator_;
+
     //js environment
     js::js_env &js_env_;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -210,7 +210,7 @@ inline std::string &trim(std::string &str, const std::string &chars = "\t\n\v\f\
   return ltrim(rtrim(str, chars), chars);
 }
 
-inline std::string &find_and_replace(std::string &str, const char *find, const char *replace)
+inline std::string &find_and_replace(std::string &&str, const char *find, const char *replace)
 {
   size_t f_len = strlen(find), r_len = strlen(replace);
   for(std::string::size_type i = 0; (i = str.find(find, i)) != std::string::npos;) {
@@ -218,6 +218,11 @@ inline std::string &find_and_replace(std::string &str, const char *find, const c
     i += r_len;
   }
   return str;
+}
+
+inline std::string &find_and_replace(std::string &str, const char *find, const char *replace)
+{
+  return find_and_replace(std::move(str), find, replace);
 }
 
 inline bool ends_with(const std::string &str, const std::string &match)
@@ -377,5 +382,32 @@ inline void clear_map_node_put_key_val(ryml::NodeRef map_node,
   map_node.clear_children();
   map_node[ryml::to_csubstr(stable_key)] << val;
 }
+
+class str_tok {
+  public:
+    explicit str_tok(const std::string &str);
+    ~str_tok();
+
+    bool next_token(std::string &out,
+                    const char *delimiters = nullptr,
+                    bool return_delimiters = false,
+                    bool *is_delimit = nullptr);
+
+    bool has_more_tokens(bool return_delimiters = false);
+
+    void reset() {
+      current_position_ = 0;
+    }
+
+  private:
+    long skip_delimit(long start_pos);
+    long scan_token(long start_pos, bool *is_delimit);
+
+  private:
+    long current_position_, max_position_, new_position_;
+    const std::string &str_;
+    std::string delimiters_;
+    bool ret_delims_, delims_changed_;
+};
 
 }

--- a/test/.astylerc
+++ b/test/.astylerc
@@ -15,7 +15,7 @@
 --indent-switches
 --indent-col1-comments
 --min-conditional-indent=2
---max-instatement-indent=100
---add-brackets
+--max-continuation-indent=100
+--add-braces
 --lineend=linux
 --convert-tabs

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 project(chatterbox_test VERSION 0.0.0)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_compile_options(-Wall -std=c++17)
+  add_compile_options(-g -Wall -std=c++17)
 endif()
 
 add_definitions(-DV8_COMPRESS_POINTERS


### PR DESCRIPTION
It is now possible to evaluate a property in the user's yaml by referencing a property in the processing output yaml.

The format for referencing a path in the output yaml is:

- {{ .property }}
- {{ .property[n] }}

And all the arbitrary compositions of the above base cases. An abbreviated format is also possible:

{{ .[n][m].property }}

This is equivalent to:

{{ .conversations[n].requests[m].property }}

Example:

conversations:
    host: localhost:7480
    requests:
      - method: POST uri: test-5/mp.3 queryString: format=json&uploads
      - method: PUT uri: test-5/mp.3 queryString: format=json&partNumber=1&uploadId={{.[0][0].response.body.UploadId}}

The queryString property in the second request is evaluated referencing the 'response.body.UploadId' path starting from the .conversations[0].requests[0] node in the output yaml.