### PR TITLE
input yaml: id on conversations and requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,52 +49,50 @@ conversations:
     secretKey: test
   requests:
     - method: POST
+      id: req1
       enabled: true
       uri: my-bucket/my-object.mp
       queryString: uploads
       auth: aws_v4
     - method: PUT
+      id: req2
       enabled: true
       uri: my-bucket/my-object.mp
-      queryString: partNumber=1&uploadId={{.[0][0].response.body.UploadId}}
+      queryString: partNumber=1&uploadId={{req1.response.body.UploadId}}
       data: "some-test-data-1"
       auth: aws_v4
     - method: POST
       enabled: true
       uri: my-bucket/my-object.mp
-      queryString: format=json&uploadId={{.[0][0].response.body.UploadId}}
+      queryString: format=json&uploadId={{req1.response.body.UploadId}}
       auth: aws_v4
       data: |
         <?xml version="1.0" encoding="UTF-8"?>
         <CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
           <Part>
-              <ETag>{{.[0][1].response.headers.ETag}}</ETag>
+              <ETag>{{req2.response.headers.ETag}}</ETag>
               <PartNumber>1</PartNumber>
           </Part>
         </CompleteMultipartUpload>
 ```
 
-As you can see, the second request is making use of the `UploadId` property
-obtained with the response's body from the first request:
+The second request is making use of the `UploadId` property
+obtained from the response's body in the first request:
 
 ```yaml
-queryString: partNumber=1&uploadId={{.[0][0].response.body.UploadId}}
+queryString: partNumber=1&uploadId={{req1.response.body.UploadId}}
 ```
 
 The syntax:
 
-```yaml
-{{.[0][0].}}
+```script
+{{req1.*}}
 ```
 
-is just a shorthand of:
-
-```yaml
-{{.conversations[0].requests[0].}}
-```
+denotes a path starting from the node identified with `id: req1` in the output `yaml`.
 
 Any property added in the output `yaml` during the conversation can be
-referenced in subsequent properties using the `{{ .property }}` syntax.
+referenced in any subsequent property using the `{{.id.*}}` syntax.
 
 ## documentation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,7 @@
     - [Conversation context](#conversation-context)
     - [Request context](#request-context)
     - [Response context](#response-context)
+    - [Referencing conversations and requests](#referencing-conversations-and-requests)
     - [Dumps and Formats](#dumps-and-formats)
   - [Scripting](#scripting)
     - [Field's value](#fields-value)
@@ -144,6 +145,36 @@ headers:
  response-foo-h1: "foo"
  response-bar-h2: "bar"
 ```
+
+### Referencing conversations and requests
+
+Any conversation or request node in the output `yaml` can be referenced in
+any subsequent node.
+
+There are currently 3 subscript syntaxes for accessing a conversations and requests:
+
+1. Full explicit path
+
+    ```script
+    {{.conversations[i].requests[j].arbitrary.path}}
+    ```
+
+2. Quick path
+
+   ```script
+   {{.[i][j].arbitrary.path}}S
+   ```
+
+3. By user defined ID
+
+   ```script
+   {{id.arbitrary.path}}
+   ```
+
+The `1` and `2` reference a conversation or a request by its natural index
+defined implicitly by the position resulted in the output yaml.
+
+The `3` uses an `id` property defined by the user for the conversation or the request.
 
 ### Dumps and Formats
 

--- a/examples/ids.yaml
+++ b/examples/ids.yaml
@@ -1,0 +1,32 @@
+conversations:
+    - host: localhost:8080
+      id: conv-1
+      requests:
+        - method: GET
+          id: req-1
+          uri: user/info
+          queryString: uid=julius
+          mock:
+            body: "{\"user\":\"mark\", \"status\":\"notFound\"}"
+            code: 404
+        - method: PUT
+          id: req-2
+          uri: user
+          queryString: uid={{req-1.response.body.user}}
+          mock:
+            body: "{\"user\":\"{{req-1.response.body.user}}\", \"status\":\"created\"}"
+            code: 200
+        - method: PUT
+          id: req-3
+          uri: user
+          queryString: sid={{.[0][1].response.body.status}}
+          mock:
+            body: "{\"user\":\"{{.[0][1].response.body.user}}\", \"status\":\"created\"}"
+            code: 200
+        - method: PUT
+          id: req-4
+          uri: user
+          queryString: sid={{.conversations[0].requests[1].response.body.status}}
+          mock:
+            body: "{\"user\":\"{{.conversations[0].requests[1].response.body.user}}\", \"status\":\"created\"}"
+            code: 200

--- a/src/conversation.h
+++ b/src/conversation.h
@@ -54,6 +54,9 @@ struct conversation {
     //scenario property evaluator
     scenario_property_evaluator &scen_p_evaluator_;
 
+    //map holding nodes with an explicit id set
+    std::unordered_map<std::string, ryml::ConstNodeRef> &indexed_nodes_map_;
+
     //js environment
     js::js_env &js_env_;
 

--- a/src/request.h
+++ b/src/request.h
@@ -114,6 +114,9 @@ struct request {
     //scenario property evaluator
     scenario_property_evaluator &scen_p_evaluator_;
 
+    //map holding nodes with an explicit id set
+    std::unordered_map<std::string, ryml::ConstNodeRef> &indexed_nodes_map_;
+
     //js environment
     js::js_env &js_env_;
 

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -13,7 +13,7 @@ namespace cbox {
 
 struct scenario_property_resolver {
 
-  scenario_property_resolver() = default;
+  scenario_property_resolver(scenario &parent) : parent_(parent) {}
 
   int init(std::shared_ptr<spdlog::logger> &event_log);
   int reset(ryml::ConstNodeRef scenario_obj_root);
@@ -21,6 +21,9 @@ struct scenario_property_resolver {
   std::optional<ryml::ConstNodeRef> resolve(const std::string &path) const;
 
   std::optional<ryml::ConstNodeRef> resolve_common(ryml::ConstNodeRef from, utils::str_tok &tknz) const;
+
+  //parent
+  scenario &parent_;
 
   ryml::ConstNodeRef scenario_obj_root_;
 
@@ -47,7 +50,7 @@ struct scenario_property_evaluator {
     std::string str_val, str_res;
     n_val >> str_val;
     str_res = str_val;
-    std::regex rgx("\\{\\{.*?\\}\\}");
+    std::regex rgx(PROP_EVAL_RGX);
 
     std::regex_iterator<std::string::const_iterator> rit(str_val.cbegin(), str_val.cend(), rgx);
     std::regex_iterator<std::string::const_iterator> rend;
@@ -182,6 +185,9 @@ struct scenario {
 
     //ryml scenario out support buffer
     std::vector<char> ryml_scenario_out_buf_;
+
+    //map holding nodes with an explicit id set
+    std::unordered_map<std::string, ryml::ConstNodeRef> indexed_nodes_map_;
 
     //scenario property resolver
     scenario_property_resolver scen_out_p_resolv_;

--- a/src/utils.h
+++ b/src/utils.h
@@ -42,6 +42,7 @@
 #define key_format          "format"
 #define key_headers         "headers"
 #define key_host            "host"
+#define key_id              "id"
 #define key_method          "method"
 #define key_mock            "mock"
 #define key_msec            "msec"


### PR DESCRIPTION
user can now specify an arbitrary id for both conversations and requests.
This eases accesses to both conversation's and request's elements.